### PR TITLE
Consistency and accuracy fixes

### DIFF
--- a/draft-mcguinness-token-xchg-target-svc-disco.md
+++ b/draft-mcguinness-token-xchg-target-svc-disco.md
@@ -53,11 +53,11 @@ informative:
         name: Karl McGuinness
       - ins: B. Campbell
         name: Brian Campbell
-    date: 2025
+    date: 2026
 
 --- abstract
 
-This specification defines a method for OAuth 2.0 clients to discover the set of available target services (audiences, resources, and scopes) for a given subject token when performing OAuth 2.0 Token Exchange. The discovery endpoint accepts any subject token type registered in the OAuth Token Type Registry and returns values that are valid inputs to subsequent Token Exchange requests, supporting advanced use cases such as identity chaining and cross-domain delegation.
+This specification defines a method for OAuth 2.0 clients to discover the set of available target services (audiences, resources, and scopes) for a given subject token when performing OAuth 2.0 Token Exchange. The discovery endpoint accepts any subject token type registered in the OAuth URI Registry and returns values that are valid inputs to subsequent Token Exchange requests, supporting advanced use cases such as identity chaining and cross-domain delegation.
 
 --- middle
 


### PR DESCRIPTION
From a consistency/accuracy review. Two small fixes, folded into the unpublished -02:

- **Abstract registry name:** changed "OAuth Token Type Registry" to "OAuth URI Registry" to match the body (Request Parameters) and RFC 8693, which registers its token-type identifiers in the OAuth URI Registry [RFC 6755]. There is no "OAuth Token Type Registry."
- **Reference freshness:** updated the ID-JAG informative reference date to 2026.

The rest of the review was clean: all references are cited, anchors resolve, examples conform to the property definitions, the URN-vs-URL `audience` guidance matches the examples, the uniqueness rule is consistent with the per-tenant audience representation, and the earlier `requested_token_types_supported` removal left no dangling references. Builds clean with kramdown-rfc + xml2rfc.