### PR TITLE
Remove stray empty build artifact; ignore generated XML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ draft-mcguinness-token-exchange-target-service-discovery.xml
 package-lock.json
 report.xml
 !requirements.txt
+
+# Generated build artifact (build to /tmp instead)
+draft-mcguinness-token-xchg-target-svc-disco.xml


### PR DESCRIPTION
The 0-byte `draft-mcguinness-token-xchg-target-svc-disco.xml` was committed by accident from a failed local build (kramdown-rfc not on PATH wrote an empty file that `git add -A` then picked up). This removes it and adds a `.gitignore` rule so the generated XML is no longer tracked. No content change to the draft.