### PR TITLE
Pin publication date (2026-06-23) for -02

### DIFF
--- a/draft-mcguinness-token-xchg-target-svc-disco.md
+++ b/draft-mcguinness-token-xchg-target-svc-disco.md
@@ -6,6 +6,7 @@ category:  "std"
 workgroup: "Web Authorization Protocol"
 area: "Security"
 ipr: "trust200902"
+date: 2026-06-23
 keyword:
   - "OAuth 2.0"
   - "Token Exchange"


### PR DESCRIPTION
Adds an explicit `date: 2026-06-23` to the frontmatter so the rendered date is stable for the -02 submission rather than defaulting to the build date. No content change; builds clean.